### PR TITLE
ci: fix missing CODECOV_TOKEN for codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,3 +30,5 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
For goplus/gop#1822

---

‼️ Steps that must be done before merging:

1. Obtain the upload token (`CODECOV_TOKEN`) from https://codecov.io/github/goplus/hdq/settings
2. Add `CODECOV_TOKEN` as a repository secret at https://github.com/goplus/hdq/settings/secrets/actions